### PR TITLE
Adds Java version configuration to pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,19 @@
     <spoon.version>3.0</spoon.version>
   </properties>
 
+  <build>
+    <plugins>
+    <plugin>
+      <artifactId>maven-compiler-plugin</artifactId>
+      <version>2.3.2</version>
+      <configuration>
+        <source>1.7</source>
+        <target>1.7</target>
+      </configuration>
+    </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>fr.inria.gforge.spoon</groupId>


### PR DESCRIPTION
By default Maven compiles with ```-source``` and ```-target``` levels at Java 1.5.
So in order to use Java 1.7, I modified the pom file as explained in this [link](http://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html).