### PR TITLE
Small improvements to examples

### DIFF
--- a/src/main/java/fr/inria/gforge/spoon/analysis/CatchProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/CatchProcessor.java
@@ -11,7 +11,7 @@ import java.util.List;
  * Reports warnings when empty catch blocks are found.
  */
 public class CatchProcessor extends AbstractProcessor<CtCatch> {
-	public final List<CtCatch> emptyCatchs = new ArrayList<CtCatch>();
+	public final List<CtCatch> emptyCatchs = new ArrayList<>();
 
 	@Override
 	public boolean isToBeProcessed(CtCatch candidate) {

--- a/src/main/java/fr/inria/gforge/spoon/analysis/CatchProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/CatchProcessor.java
@@ -15,7 +15,7 @@ public class CatchProcessor extends AbstractProcessor<CtCatch> {
 
 	@Override
 	public boolean isToBeProcessed(CtCatch candidate) {
-		return candidate.getBody().getStatements().size() == 0;
+		return candidate.getBody().getStatements().isEmpty();
 	}
 
 	@Override

--- a/src/main/java/fr/inria/gforge/spoon/analysis/DocProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/DocProcessor.java
@@ -15,7 +15,7 @@ import java.util.List;
  * Reports warnings when undocumented elements are found.
  */
 public class DocProcessor extends AbstractProcessor<CtElement> {
-	public final List<CtElement> undocumentedElements = new ArrayList<CtElement>();
+	public final List<CtElement> undocumentedElements = new ArrayList<>();
 
 	public void process(CtElement element) {
 		if (element instanceof CtNamedElement || element instanceof CtField || element instanceof CtExecutable) {

--- a/src/main/java/fr/inria/gforge/spoon/analysis/DocProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/DocProcessor.java
@@ -6,11 +6,14 @@ import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtNamedElement;
-import spoon.reflect.declaration.ModifierKind;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import spoon.reflect.declaration.ModifierKind;
 
+import static spoon.reflect.declaration.ModifierKind.PUBLIC;
+import static spoon.reflect.declaration.ModifierKind.PROTECTED;
 /**
  * Reports warnings when undocumented elements are found.
  */
@@ -19,8 +22,10 @@ public class DocProcessor extends AbstractProcessor<CtElement> {
 
 	public void process(CtElement element) {
 		if (element instanceof CtNamedElement || element instanceof CtField || element instanceof CtExecutable) {
-			if (((CtModifiable) element).getModifiers().contains(ModifierKind.PUBLIC) || ((CtModifiable) element).getModifiers().contains(ModifierKind.PROTECTED)) {
-				if (element.getDocComment() == null || element.getDocComment().equals("")) {
+                    Set<ModifierKind> modifiers = ((CtModifiable) element).getModifiers();
+			if (modifiers.contains(PUBLIC) || modifiers.contains(PROTECTED)) {
+                            String docComment = element.getDocComment();
+				if (docComment == null || docComment.equals("")) {
 					undocumentedElements.add(element);
 				}
 			}

--- a/src/main/java/fr/inria/gforge/spoon/analysis/EmptyMethodBodyProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/EmptyMethodBodyProcessor.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public class EmptyMethodBodyProcessor extends AbstractProcessor<CtMethod<?>> {
 
-	public final List<CtMethod> emptyMethods = new ArrayList<CtMethod>();
+	public final List<CtMethod> emptyMethods = new ArrayList<>();
 	public void process(CtMethod<?> element) {
 		if (element.getParent(CtClass.class) != null && !element.getModifiers().contains(ModifierKind.ABSTRACT) && element.getBody().getStatements().size() == 0) {
 			emptyMethods.add(element);

--- a/src/main/java/fr/inria/gforge/spoon/analysis/EmptyMethodBodyProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/EmptyMethodBodyProcessor.java
@@ -15,7 +15,7 @@ public class EmptyMethodBodyProcessor extends AbstractProcessor<CtMethod<?>> {
 
 	public final List<CtMethod> emptyMethods = new ArrayList<>();
 	public void process(CtMethod<?> element) {
-		if (element.getParent(CtClass.class) != null && !element.getModifiers().contains(ModifierKind.ABSTRACT) && element.getBody().getStatements().size() == 0) {
+		if (element.getParent(CtClass.class) != null && !element.getModifiers().contains(ModifierKind.ABSTRACT) && element.getBody().getStatements().isEmpty()) {
 			emptyMethods.add(element);
 		}
 	}

--- a/src/main/java/fr/inria/gforge/spoon/analysis/FactoryProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/FactoryProcessor.java
@@ -2,9 +2,7 @@ package fr.inria.gforge.spoon.analysis;
 
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.code.CtConstructorCall;
-import spoon.reflect.code.CtNewClass;
 import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 

--- a/src/main/java/fr/inria/gforge/spoon/analysis/FactoryProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/FactoryProcessor.java
@@ -23,7 +23,7 @@ public class FactoryProcessor extends AbstractProcessor<CtConstructorCall<?>> {
 		if (newClass.getExecutable().getDeclaringType().isSubtypeOf(getFactoryType()))
 			return;
 		// skip creations in factories
-		if (((CtClass<?>) newClass.getParent(CtClass.class)).isSubtypeOf(getFactoryType()))
+		if (newClass.getParent(CtClass.class).isSubtypeOf(getFactoryType()))
 			return;
 		// only report for types created by the factory
 		for (CtTypeReference<?> t : getCreatedTypes()) {

--- a/src/main/java/fr/inria/gforge/spoon/analysis/FactoryProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/FactoryProcessor.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class FactoryProcessor extends AbstractProcessor<CtConstructorCall<?>> {
 
-	public List<CtConstructorCall> listWrongUses = new ArrayList<CtConstructorCall>();
+	public List<CtConstructorCall> listWrongUses = new ArrayList<>();
 	private CtTypeReference factoryTypeRef;
 
 	public FactoryProcessor(CtTypeReference factoryTypeRef) {

--- a/src/main/java/fr/inria/gforge/spoon/analysis/ReferenceProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/ReferenceProcessor.java
@@ -24,8 +24,8 @@ import java.util.Stack;
  */
 public class ReferenceProcessor extends AbstractProcessor<CtPackage> {
 
-	private List<CtTypeReference<?>> ignoredTypes = new ArrayList<CtTypeReference<?>>();
-	public List<List<CtPackageReference>> circularPathes = new ArrayList<List<CtPackageReference>>();
+	private List<CtTypeReference<?>> ignoredTypes = new ArrayList<>();
+	public List<List<CtPackageReference>> circularPathes = new ArrayList<>();
 
 	@Override
 	public void init() {
@@ -34,13 +34,13 @@ public class ReferenceProcessor extends AbstractProcessor<CtPackage> {
 		ignoredTypes.add(getFactory().Type().createReference(FactoryAccessor.class));
 	}
 
-	Map<CtPackageReference, Set<CtPackageReference>> packRefs = new HashMap<CtPackageReference, Set<CtPackageReference>>();
+	Map<CtPackageReference, Set<CtPackageReference>> packRefs = new HashMap<>();
 
 	public void process(CtPackage element) {
 		CtPackageReference pack = element.getReference();
-		Set<CtPackageReference> refs = new HashSet<CtPackageReference>();
+		Set<CtPackageReference> refs = new HashSet<>();
 		for (CtType t : element.getTypes()) {
-			List<CtTypeReference<?>> listReferences = Query.getReferences(t, new ReferenceTypeFilter<CtTypeReference<?>>(CtTypeReference.class));
+			List<CtTypeReference<?>> listReferences = Query.getReferences(t, new ReferenceTypeFilter<>(CtTypeReference.class));
 
 			for (CtTypeReference<?> tref : listReferences) {
 				if (tref.getPackage() != null && !tref.getPackage().equals(pack)) {
@@ -58,13 +58,13 @@ public class ReferenceProcessor extends AbstractProcessor<CtPackage> {
 	@Override
 	public void processingDone() {
 		for (CtPackageReference p : packRefs.keySet()) {
-			Stack<CtPackageReference> path = new Stack<CtPackageReference>();
+			Stack<CtPackageReference> path = new Stack<>();
 			path.push(p);
 			scanDependencies(path);
 		}
 	}
 
-	Set<CtPackageReference> scanned = new HashSet<CtPackageReference>();
+	Set<CtPackageReference> scanned = new HashSet<>();
 
 	void scanDependencies(Stack<CtPackageReference> path) {
 		CtPackageReference ref = path.peek();
@@ -77,7 +77,7 @@ public class ReferenceProcessor extends AbstractProcessor<CtPackage> {
 		if (refs != null) {
 			for (CtPackageReference p : refs) {
 				if (path.contains(p)) {
-					List<CtPackageReference> circularPath = new ArrayList<CtPackageReference>(
+					List<CtPackageReference> circularPath = new ArrayList<>(
 							path.subList(path.indexOf(p), path.size()));
 					circularPath.add(p);
 

--- a/src/main/java/fr/inria/gforge/spoon/analysis/ReferenceProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/ReferenceProcessor.java
@@ -50,7 +50,7 @@ public class ReferenceProcessor extends AbstractProcessor<CtPackage> {
 				}
 			}
 		}
-		if (refs.size() > 0) {
+		if (!refs.isEmpty()) {
 			packRefs.put(pack, refs);
 		}
 	}

--- a/src/main/java/fr/inria/gforge/spoon/analysis/ReferenceProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/analysis/ReferenceProcessor.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
-import java.util.TreeSet;
 
 /**
  * Finds circular dependencies between packages

--- a/src/main/java/fr/inria/gforge/spoon/assertgenerator/Logger.java
+++ b/src/main/java/fr/inria/gforge/spoon/assertgenerator/Logger.java
@@ -10,7 +10,7 @@ import java.util.Map;
  */
 public class Logger {
 
-	public static Map<String, Object> observations = new HashMap<String, Object>();
+	public static Map<String, Object> observations = new HashMap<>();
 
 	public static void observe(String name, Object object) {
 		observations.put(name, object);

--- a/src/main/java/fr/inria/gforge/spoon/assertgenerator/test/TestListener.java
+++ b/src/main/java/fr/inria/gforge/spoon/assertgenerator/test/TestListener.java
@@ -14,13 +14,8 @@ import java.util.List;
  */
 class TestListener extends RunListener {
 
-    private List<Description> testRun;
-    private List<Failure> testFails;
-
-    TestListener() {
-        this.testRun = new ArrayList<>();
-        this.testFails = new ArrayList<>();
-    }
+    private final List<Description> testRun = new ArrayList<>();
+    private final List<Failure> testFails = new ArrayList<>();
 
     @Override
     public synchronized void testFinished(Description description) throws Exception {

--- a/src/main/java/fr/inria/gforge/spoon/assertgenerator/workflow/Collector.java
+++ b/src/main/java/fr/inria/gforge/spoon/assertgenerator/workflow/Collector.java
@@ -17,6 +17,7 @@ import java.util.List;
 import static fr.inria.gforge.spoon.assertgenerator.Util.getGetters;
 import static fr.inria.gforge.spoon.assertgenerator.Util.getKey;
 import static fr.inria.gforge.spoon.assertgenerator.Util.invok;
+import java.net.MalformedURLException;
 
 /**
  * Created by Benjamin DANGLOT
@@ -32,9 +33,9 @@ public class Collector {
 	}
 
 	public void collect(Launcher launcher, CtMethod<?> testMethod, List<CtLocalVariable> localVariables) {
-		final CtClass testClass = testMethod.getParent(CtClass.class);
+		CtClass testClass = testMethod.getParent(CtClass.class);
 		testClass.removeMethod(testMethod);
-		final CtMethod<?> clone = testMethod.clone();
+		CtMethod<?> clone = testMethod.clone();
 		instrument(clone, localVariables);
 		testClass.addMethod(clone);
 		System.out.println(clone);
@@ -44,13 +45,13 @@ public class Collector {
 	}
 
 	public void run(Launcher launcher, CtClass testClass, CtMethod<?> clone) {
-		final String fullQualifiedName = testClass.getQualifiedName();
-		final String testMethodName = clone.getSimpleName();
+		String fullQualifiedName = testClass.getQualifiedName();
+		String testMethodName = clone.getSimpleName();
 		try {
 			final SpoonModelBuilder compiler = launcher.createCompiler();
 			compiler.compile(SpoonModelBuilder.InputType.CTTYPES);
 			TestRunner.runTest(fullQualifiedName, testMethodName, new String[]{"spooned-classes"});
-		} catch (Exception e) {
+		} catch (ClassNotFoundException | MalformedURLException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/main/java/fr/inria/gforge/spoon/transformation/bound/processing/BoundTemplateProcessor.java
+++ b/src/main/java/fr/inria/gforge/spoon/transformation/bound/processing/BoundTemplateProcessor.java
@@ -20,7 +20,7 @@ public class BoundTemplateProcessor extends AbstractAnnotationProcessor<Bound, C
 		}
 
 		// Use template.
-		CtClass<?> type = (CtClass<?>) e.getParent(CtClass.class);
+		CtClass<?> type = e.getParent(CtClass.class);
 		Template t = new BoundTemplate(getFactory().Type().createReference(Double.class), element.getSimpleName(), annotation.min(), annotation.max());
 		final CtBlock apply = (CtBlock) t.apply(type);
 

--- a/src/main/java/fr/inria/gforge/spoon/transformation/mutation/MutationTester.java
+++ b/src/main/java/fr/inria/gforge/spoon/transformation/mutation/MutationTester.java
@@ -29,10 +29,10 @@ public class MutationTester<T> {
 	private Processor mutator;
 	
 	/** the produced mutants */
-	private final List<CtClass> mutants = new ArrayList<CtClass>();
+	private final List<CtClass> mutants = new ArrayList<>();
 
 	// public for testing
-	public final List<T> mutantInstances = new ArrayList<T>();
+	public final List<T> mutantInstances = new ArrayList<>();
 
 	public MutationTester(String src, TestDriver tester, Processor mutator) {
 		this.sourceCodeToBeMutated = src;

--- a/src/main/java/fr/inria/gforge/spoon/transformation/mutation/MutationTester.java
+++ b/src/main/java/fr/inria/gforge/spoon/transformation/mutation/MutationTester.java
@@ -92,11 +92,11 @@ public class MutationTester<T> {
 	
 	private void replace(CtElement e, CtElement op) {
 		if (e instanceof CtStatement  && op instanceof CtStatement) {
-			((CtStatement)e).replace((CtStatement) op);			
+			e.replace(op);
 			return;
 		}
 		if (e instanceof CtExpression && op instanceof CtExpression) {
-			((CtExpression)e).replace((CtExpression) op);
+			e.replace(op);
 			return;
 		}
 		throw new IllegalArgumentException(e.getClass()+" "+op.getClass());
@@ -105,7 +105,7 @@ public class MutationTester<T> {
 	/** tries to kill all generated mutants, throws an AssertionError if one mutant is not killed */
 	public void killMutants() throws Exception {
 		
-		List<Class> compiledMutants = compileMutants(mutants);
+		List<Class<?>> compiledMutants = compileMutants(mutants);
 
 		List<T> mutantInstances = instantiateMutants(compiledMutants);
 
@@ -127,7 +127,7 @@ public class MutationTester<T> {
 	}
 
 	/** instantiate the mutant classes using the default zero-arg constructor */
-	public List<T> instantiateMutants(List<Class> compiledMutants)
+	public List<T> instantiateMutants(List<Class<?>> compiledMutants)
 			throws Exception {
 		// we run each mutant one by one and check whether they are killed
 
@@ -139,8 +139,8 @@ public class MutationTester<T> {
 	}
 
 	/** compiles the mutants on the fly */
-	public List<Class> compileMutants(List<CtClass> mutants) throws Exception {
-		List<Class> compiledMutants = new ArrayList<Class>();
+	public List<Class<?>> compileMutants(List<CtClass> mutants) throws Exception {
+		List<Class<?>> compiledMutants = new ArrayList<>();
 		for (CtClass mutantClass : mutants) {
 			Class<?> klass = InMemoryJavaCompiler.newInstance().compile(
 					mutantClass.getQualifiedName(), "package "

--- a/src/main/java/fr/inria/gforge/spoon/transformation/retry/RetryOnFailure.java
+++ b/src/main/java/fr/inria/gforge/spoon/transformation/retry/RetryOnFailure.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.concurrent.TimeUnit;
 
 /**
  * This annotation is inspirited by JCabi retry annotation.

--- a/src/test/java/fr/inria/gforge/spoon/analysis/CatchProcessorTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/analysis/CatchProcessorTest.java
@@ -6,9 +6,6 @@ import spoon.Launcher;
 import spoon.processing.ProcessingManager;
 import spoon.reflect.factory.Factory;
 import spoon.support.QueueProcessingManager;
-import spoon.support.compiler.FileSystemFolder;
-
-import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/fr/inria/gforge/spoon/analysis/DocProcessorTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/analysis/DocProcessorTest.java
@@ -7,7 +7,6 @@ import spoon.reflect.factory.Factory;
 import spoon.support.QueueProcessingManager;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class DocProcessorTest {

--- a/src/test/java/fr/inria/gforge/spoon/analysis/FactoryProcessorTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/analysis/FactoryProcessorTest.java
@@ -35,7 +35,7 @@ public class FactoryProcessorTest {
 		final FactoryProcessor processor = new FactoryProcessor(listFactoryItf.get(0).getReference());
 		processingManager.addProcessor(processor);
 
-		List<CtConstructorCall> ctNewClasses = factory.getModel().getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class));
+		List<CtConstructorCall> ctNewClasses = factory.getModel().getElements(new TypeFilter<>(CtConstructorCall.class));
 		processingManager.process(ctNewClasses);
 
 		// implicit constructor is also counted

--- a/src/test/java/fr/inria/gforge/spoon/assertgenerator/AssertionGenerationTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/assertgenerator/AssertionGenerationTest.java
@@ -73,9 +73,10 @@ public class AssertionGenerationTest {
 				}
 			}.start();
 			p.waitFor();
-			BufferedReader buffer = new BufferedReader(new FileReader(".cp"));
-			final String classpath = buffer.lines().collect(Collectors.joining(System.getProperty("path.separator")));
-			buffer.close();
+			final String classpath;
+                    try (BufferedReader buffer = new BufferedReader(new FileReader(".cp"))) {
+                        classpath = buffer.lines().collect(Collectors.joining(System.getProperty("path.separator")));
+                    }
 			return classpath.split(System.getProperty("path.separator"));
 		} catch (Exception e) {
 			throw new RuntimeException(e);

--- a/src/test/java/fr/inria/gforge/spoon/assertgenerator/AssertionGenerationTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/assertgenerator/AssertionGenerationTest.java
@@ -78,7 +78,7 @@ public class AssertionGenerationTest {
                         classpath = buffer.lines().collect(Collectors.joining(System.getProperty("path.separator")));
                     }
 			return classpath.split(System.getProperty("path.separator"));
-		} catch (Exception e) {
+		} catch (IOException | InterruptedException e) {
 			throw new RuntimeException(e);
 		}
 

--- a/src/test/java/fr/inria/gforge/spoon/assertgenerator/AssertionGenerationTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/assertgenerator/AssertionGenerationTest.java
@@ -5,19 +5,15 @@ import fr.inria.gforge.spoon.assertgenerator.workflow.AssertionAdder;
 import fr.inria.gforge.spoon.assertgenerator.workflow.Collector;
 import org.junit.Test;
 import spoon.Launcher;
-import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
-import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.reference.CtExecutableReference;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 

--- a/src/test/java/fr/inria/gforge/spoon/transformation/LogProcessorTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/transformation/LogProcessorTest.java
@@ -1,12 +1,8 @@
 package fr.inria.gforge.spoon.transformation;
 
-import org.eclipse.jdt.internal.compiler.batch.Main;
 import org.junit.Test;
 import spoon.Launcher;
 
-import java.io.PrintWriter;
-
-import static org.junit.Assert.assertTrue;
 
 public class LogProcessorTest {
 	@Test

--- a/src/test/java/fr/inria/gforge/spoon/transformation/MutationTesterTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/transformation/MutationTesterTest.java
@@ -34,7 +34,7 @@ public class MutationTesterTest {
 		BinaryOperatorMutator mutationOperator = new BinaryOperatorMutator();
 
 		// we instantiate the mutation tester
-		MutationTester<IFoo> mutationTester = new MutationTester<IFoo>(codeToBeMutated, testDriverForIFooObjects, mutationOperator);
+		MutationTester<IFoo> mutationTester = new MutationTester<>(codeToBeMutated, testDriverForIFooObjects, mutationOperator);
 		
 		// generating the mutants
 		mutationTester.generateMutants();

--- a/src/test/java/fr/inria/gforge/spoon/transformation/NotNullCheckAdderProcessorTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/transformation/NotNullCheckAdderProcessorTest.java
@@ -1,13 +1,7 @@
 package fr.inria.gforge.spoon.transformation;
 
-import org.eclipse.jdt.internal.compiler.batch.Main;
 import org.junit.Test;
 import spoon.Launcher;
-import spoon.reflect.declaration.CtClass;
-
-import java.io.PrintWriter;
-
-import static org.junit.Assert.assertTrue;
 
 public class NotNullCheckAdderProcessorTest {
 	@Test

--- a/src/test/java/fr/inria/gforge/spoon/transformation/retry/RetryTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/transformation/retry/RetryTest.java
@@ -37,7 +37,7 @@ public class RetryTest {
 		try {
 			clz.getMethod("retry").invoke(instance);
 			Assert.fail("retry method should always fail");
-		} catch (Exception ex) {
+		} catch (ReflectiveOperationException | IllegalArgumentException | SecurityException ex) {
 			// always fail
 		}
 		Field field = clz.getDeclaredField("result");

--- a/src/test/java/fr/inria/gforge/spoon/transformation/retry/TestClass.java
+++ b/src/test/java/fr/inria/gforge/spoon/transformation/retry/TestClass.java
@@ -8,7 +8,7 @@ import java.util.Collection;
  */
 public class TestClass {
 
-	private Collection<Long> result = new ArrayList<Long>();
+	private Collection<Long> result = new ArrayList<>();
 
 	@RetryOnFailure(attempts = 3, delay = 10, verbose = false)
 	public void retry() {

--- a/src/test/java/fr/inria/gforge/spoon/utils/SpoonClassLoader.java
+++ b/src/test/java/fr/inria/gforge/spoon/utils/SpoonClassLoader.java
@@ -30,14 +30,15 @@ public class SpoonClassLoader extends ClassLoader {
 				return super.loadClass(name);
 			}
 
-			InputStream input = new FileInputStream(file);
-			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-			int data = input.read();
-			while (data != -1) {
-				buffer.write(data);
-				data = input.read();
-			}
-			input.close();
+                        ByteArrayOutputStream buffer;
+                    try (InputStream input = new FileInputStream(file)) {
+                        buffer = new ByteArrayOutputStream();
+                        int data = input.read();
+                        while (data != -1) {
+                            buffer.write(data);
+                            data = input.read();
+                        }
+                    }
 			byte[] classData = buffer.toByteArray();
 
 			return defineClass(name, classData, 0, classData.length);

--- a/src/test/java/fr/inria/gforge/spoon/utils/TestSpoonCompiler.java
+++ b/src/test/java/fr/inria/gforge/spoon/utils/TestSpoonCompiler.java
@@ -44,7 +44,7 @@ public class TestSpoonCompiler extends JDTBasedSpoonCompiler {
 			getFactory().getEnvironment().debugMessage(
 					"Generating source files to: " + getSourceOutputDirectory());
 
-			List<File> printedFiles = new ArrayList<File>();
+			List<File> printedFiles = new ArrayList<>();
 			printing:
 			for (spoon.reflect.cu.CompilationUnit cu : getFactory().CompilationUnit()
 					.getMap().values()) {

--- a/src/test/java/fr/inria/gforge/spoon/utils/TestSpooner.java
+++ b/src/test/java/fr/inria/gforge/spoon/utils/TestSpooner.java
@@ -63,7 +63,7 @@ public class TestSpooner {
 		// Build spoon model
 		compiler.build();
 		
-		List<Processor<?>> processorsNames = new ArrayList<Processor<?>>();
+		List<Processor<?>> processorsNames = new ArrayList<>();
 		for (Class<? extends Processor> processor : processors) {
 			processorsNames.add(processor.newInstance());
 		}


### PR DESCRIPTION
This is a list of patches for improvements to the examples. Some of them will be non controversial like the removing of unused imports. Some of them will be problematic - I am fine with you not accepting all of them. As these have already been used in presentations - perhaps you may prefer to keep presentation and source in sync or you decide the cost of change is bigger than the improvement.
I have tried to make source shorter, perhaps using less characters per line at the expense of some more lines that can be actually skipped in a presentation.
Please note - all interim versions are compilable, so it should be possible to skip patches, which are organized on a theme or a file.
I have the feeling that while source and binary compatibility are set to 1.8, the author of the examples used and IDE geared towards 1.7.
I will try to create more examples and create a pull request for them.