### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 					<!-- the following is required to have the same execution semantics 
 						as eclipse (hence all tests passing) -->
 					<useSystemClassLoader>false</useSystemClassLoader>
-					<forkCount>1</forkCount>
+					<forkCount>1.5C</forkCount>
 					<argLine>-Dgumtree.match.gt.minh=1</argLine>
                                         <!-- we put the tests in src/main/java so that it's easier to navigate and understand on Github (recall that's an example code project, not a production app or library ) -->
                                         <testSourceDirectory>${basedir}/src/main/java/</testSourceDirectory>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
